### PR TITLE
TEST: reorder tests and fix the path of patch

### DIFF
--- a/dbod/tests/rundeck_test.py
+++ b/dbod/tests/rundeck_test.py
@@ -6,15 +6,13 @@
 # or submit itself to any jurisdiction.
 
 import unittest
-from types import *
-import json
 import logging
-import sys
-import requests
 
 import base64
 import tornado.web
+import requests
 
+from sys import stdout
 from mock import patch
 from mock import MagicMock
 from tornado.testing import AsyncHTTPTestCase
@@ -22,10 +20,10 @@ from timeout_decorator import timeout
 
 from dbod.api.api import handlers
 from dbod.config import config
-logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+logging.basicConfig(stream=stdout, level=logging.DEBUG)
 
-class RundeckJobsTest(AsyncHTTPTestCase, unittest.TestCase):
-    """Class for testing Rundeck job execution with nosetest"""
+class RundeckTest(AsyncHTTPTestCase, unittest.TestCase):
+    """Class for testing Rundeck execution with nosetest"""
     
     authentication = "basic " + \
                      base64.b64encode(config.get('api', 'user') + \
@@ -34,9 +32,39 @@ class RundeckJobsTest(AsyncHTTPTestCase, unittest.TestCase):
     def get_app(self):
         return tornado.web.Application(handlers)
 
+    @patch('dbod.api.rundeck.requests.get')
+    def test_get_success(self, mock_get):
+        """test when get method is successful"""
+        print "test_get_success"
+        status_code_test = 200
+        response_text = '[{"db_name":"dbod42","hostname":"dbod42.cern.ch","port":"5500","username":"dbod","db_type":"MYSQL","category":"TEST","tags":"MYSQL,TEST"}, \
+        {"db_name":"dbod24","hostname":"dbod24.cern.ch","port":"6603","username":"dbod","db_type":"PG","category":"PROD","tags":"PG,PROD"}]'
+
+        mock_get.return_value = MagicMock(spec=requests.models.Response,
+                                          ok=True,
+                                          status_code=status_code_test,
+                                          text=response_text)
+
+        response = self.fetch("/api/v1/rundeck/resources.xml")
+        
+        self.assertEquals(response.code, 200)
+
+    @patch('dbod.api.rundeck.requests.get')
+    def test_get_nosuccess(self, mock_get):
+        """test when get method is not successful """
+        print "test_get_nosuccess"
+        status_code_test_error = 502
+
+        mock_get.return_value = MagicMock(spec=requests.models.Response,
+                                          ok=False,
+                                          status_code=status_code_test_error)
+
+        response = self.fetch("/api/v1/rundeck/resources.xml")
+        self.assertEquals(response.code, 404)
+    
     @timeout(10)
-    @patch('dbod.api.functionalalias.requests.get')
-    @patch('dbod.api.functionalalias.requests.post')
+    @patch('dbod.api.rundeck.requests.get')
+    @patch('dbod.api.rundeck.requests.post')
     def test_post_job_success(self, mock_post, mock_get):
         """test an execution of a registered job of an existing instance"""
         print "test_post_existing_instance"
@@ -64,8 +92,8 @@ class RundeckJobsTest(AsyncHTTPTestCase, unittest.TestCase):
                              body='')
         self.assertEquals(response.code, 200)
         
-    @patch('dbod.api.functionalalias.requests.get')
-    @patch('dbod.api.functionalalias.requests.post')
+    @patch('dbod.api.rundeck.requests.get')
+    @patch('dbod.api.rundeck.requests.post')
     def test_post_job_nosuccess(self, mock_post, mock_get):
         """test when the job execution is not successful"""
         print "test_post_job_nosuccess"
@@ -88,8 +116,8 @@ class RundeckJobsTest(AsyncHTTPTestCase, unittest.TestCase):
                                body='')
         self.assertEquals(response.code, 502)
     
-    @patch('dbod.api.functionalalias.requests.get')
-    @patch('dbod.api.functionalalias.requests.post')
+    @patch('dbod.api.rundeck.requests.get')
+    @patch('dbod.api.rundeck.requests.post')
     def test_post_jobstatus_error(self, mock_post, mock_get):
         """test when the the get request of the job from rundeck status is not successful"""
         print "test_post_jobstatus_error"
@@ -113,10 +141,11 @@ class RundeckJobsTest(AsyncHTTPTestCase, unittest.TestCase):
                                body='')
         self.assertEquals(response.code, status_code_test_error)
 
-    @patch('dbod.api.functionalalias.requests.get')
-    @patch('dbod.api.functionalalias.requests.post')
+    @patch('dbod.api.rundeck.requests.get')
+    @patch('dbod.api.rundeck.requests.post')
     def test_post_jobrun_error(self, mock_post, mock_get):
         """test when the the post request of the job to rundeck is not successful"""
+        print "test_post_jobrun_error"
         status_code_test = 200
         status_code_test_error = 400
         response_run = '{"id":42}'
@@ -134,30 +163,4 @@ class RundeckJobsTest(AsyncHTTPTestCase, unittest.TestCase):
                                body='')
 
         self.assertEquals(response.code, status_code_test_error)   
-
-    @patch('dbod.api.functionalalias.requests.get')
-    def test_get_success(self, mock_get):
-        status_code_test = 200
-        response_text = '[{"db_name":"dbod42","hostname":"dbod42.cern.ch","port":"5500","username":"dbod","db_type":"MYSQL","category":"TEST","tags":"MYSQL,TEST"}, \
-        {"db_name":"dbod24","hostname":"dbod24.cern.ch","port":"6603","username":"dbod","db_type":"PG","category":"PROD","tags":"PG,PROD"}]'
-
-        mock_get.return_value = MagicMock(spec=requests.models.Response,
-                                          ok=True,
-                                          status_code=status_code_test,
-                                          text=response_text)
-
-        response = self.fetch("/api/v1/rundeck/resources.xml")
-        
-        self.assertEquals(response.code, 200)
-
-    @patch('dbod.api.functionalalias.requests.get')
-    def test_get_nosuccess(self, mock_get):
-        status_code_test_error = 502
-
-        mock_get.return_value = MagicMock(spec=requests.models.Response,
-                                          ok=False,
-                                          status_code=status_code_test_error)
-
-        response = self.fetch("/api/v1/rundeck/resources.xml")
-        print response
-        self.assertEquals(response.code, 404)   
+ 


### PR DESCRIPTION
Closes #60
Make the tests to correspond to the path and the order of dbod.api.rundeck. 
Also, unused libraries are removed.